### PR TITLE
Fix deprecated device_state_attributes

### DIFF
--- a/custom_components/artnet_led/light.py
+++ b/custom_components/artnet_led/light.py
@@ -202,7 +202,7 @@ class ArtnetBaseLight(LightEntity):
         return self._features
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         data = {}
         data["dmx_channels"] = [
             k


### PR DESCRIPTION
Fix warning 'Entity light.name(<class 'custom_components.artnet_led.light.ArtnetRGBW'>) implements device_state_attributes. Please report it to the custom component author.'